### PR TITLE
Add option to purge build directory between runs

### DIFF
--- a/decent_ci_config.yaml
+++ b/decent_ci_config.yaml
@@ -11,11 +11,17 @@ environment:
   DECENT_CI_BRANCH_FILTER: ".*"
   DECENT_CI_COMPILER_FILTER: ".*"
 test_mode: true
+# use this to try and clean up build dirs that are left around
+# between executions. It matches files in the run_dir of the 
+# form: /^.+-[0-0a-f]+-.+-.+-.+$/
+purge_build_dirs: false
 github_token: "ABCDEF1234567890"
 options:
   - "--no-verbose"
 # You probably want to uncomment this on Windows
 #  - "--disable-ssl-verification"
+#  Use this for testing
+#  - "--keep-build-folder"
 repositories:
   - "NREL/EnergyPlus"  
 

--- a/decent_ci_run.rb
+++ b/decent_ci_run.rb
@@ -51,7 +51,7 @@ begin
 
       break
     rescue => e 
-      puts "Error setting up build folders, sleeping and trying again"
+      puts "Error setting up build folders, sleeping and trying again: #{e}"
       sleep 120
     end
   end
@@ -72,11 +72,22 @@ begin
   puts "Successfully cloned decent_ci repository."
 
   FileUtils.cd(run_dir)
+  
+  if !config["purge_build_dirs"].nil? and config["purge_build_dirs"] then
+    puts "Purging Build Dirs in #{run_dir}"
+    Dir.entries(run_dir).each { |entry|
+      if File.directory?(entry) and entry =~ /^.+-[a-f0-9]+-.+-.+$/ then
+        puts "Purging matched directory: #{entry}"
+        FileUtils.remove_entry_secure(entry, true)
+      end
+    }
+  end
 
   puts "Running ci.rb"
   if !system(merged_env, "#{RbConfig.ruby}", "#{run_dir}/decent_ci/ci.rb", *config["options"], config["test_mode"] ? "true" : "false", config["github_token"], *config["repositories"])
     puts "Unable to execute ci.rb script"
   end
+
 
 rescue => e
   puts "Error setting up build environment #{e}"

--- a/decent_ci_run.rb
+++ b/decent_ci_run.rb
@@ -76,9 +76,13 @@ begin
   if !config["purge_build_dirs"].nil? and config["purge_build_dirs"] then
     puts "Purging Build Dirs in #{run_dir}"
     Dir.entries(run_dir).each { |entry|
-      if File.directory?(entry) and entry =~ /^.+-[a-f0-9]+-.+-.+$/ then
-        puts "Purging matched directory: #{entry}"
-        FileUtils.remove_entry_secure(entry, true)
+      begin
+        if File.directory?(entry) and entry =~ /^.+-[a-f0-9]+-.+-.+$/ then
+          puts "Purging matched directory: #{entry}"
+          FileUtils.remove_entry_secure(entry, true)
+        end
+      rescue => e
+        puts "Error while attempting purge of build dir '#{entry}': '#{e}'"
       end
     }
   end


### PR DESCRIPTION
with the json configuration option `purge_build_dirs` the decent_ci_runner looks for existing build dirs in the build path and attempts to delete them before continuing.