### PR TITLE
Add requirements for clang_format and 179D

### DIFF
--- a/linux/packages.yaml
+++ b/linux/packages.yaml
@@ -51,6 +51,8 @@ packages:
     source: apt
   - name: clang-3.5
     source: apt
+  - name: clang-format-3.5
+    source: apt
   - name: python3 
     source: apt
   - name: python3-yaml 
@@ -68,6 +70,8 @@ packages:
   - name: curl
     source: apt
   - name: texlive-full
+    source: apt
+  - name: libwxgtk3.0
     source: apt
 
   - name: EnergyPlus
@@ -87,5 +91,10 @@ packages:
   - name: le
     source: gem2.0
   - name: deep_merge
+    source: gem2.0
+  - name: nokogiri
+    source: gem2.0
+    version: 1.6.8.1
+  - name: rubyXL
     source: gem2.0
 

--- a/linux/packages.yaml
+++ b/linux/packages.yaml
@@ -51,7 +51,7 @@ packages:
     source: apt
   - name: clang-3.5
     source: apt
-  - name: clang-format-3.5
+  - name: clang-format-3.9
     source: apt
   - name: python3 
     source: apt


### PR DESCRIPTION
These two unrelated projects have been merged into one commit
to minimize the impact on the CI.

After this change is merged the CI will fail to execute until the
required dependencies have been installed.

Notes:

 - nokogiri is manually installed and fixed at the last version that
   supports ruby 2.0
 - rubyXL is required for handling of the excel spreadsheets for 179d
 - clang-format-3.5 has been chosen to be consistent with clang++,
   however this could be adjusted as high as 3.9, which should be
   considered